### PR TITLE
Simplify time left formatting

### DIFF
--- a/terminal_clock.py
+++ b/terminal_clock.py
@@ -25,8 +25,7 @@ try:
 
         # find remaining duration
         time_left = t2 - t1
-        time_left_string = str(time_left)
-        time_left_string = time_left_string[:-3]
+        time_left_string = str(time_left).split('.')[0]
 
         # Progress Bar Conter if time is above 09.00
         if t1 >= t3 and t1 <= t2:

--- a/terminal_clockv3.py
+++ b/terminal_clockv3.py
@@ -23,8 +23,7 @@ try:
 
         # find remaining duration
         time_left = t2 - t1
-        time_left_string = str(time_left)
-        time_left_string = time_left_string[:-3]
+        time_left_string = str(time_left).split('.')[0]
 
         # Progress Bar Conter if time is above 09.00
         if t1 >= t3 and t1 <= t2:


### PR DESCRIPTION
## Summary
- simplify the string formatting for the remaining time

## Testing
- `python -m py_compile terminal_clock.py terminal_clockv3.py`

------
https://chatgpt.com/codex/tasks/task_e_684058dc930483258b764b47e335f450