### PR TITLE
Fix uninitialized bar in v3 clock script

### DIFF
--- a/terminal_clockv3.py
+++ b/terminal_clockv3.py
@@ -10,6 +10,7 @@ t3 = timedelta(hours=9, minutes=00, seconds=00)
 out_of_scope = "N/A"
 ascii_none = pyfiglet.figlet_format(out_of_scope)
 prog_counter = 0
+bar = None
 
 try:
     while True:
@@ -55,7 +56,7 @@ try:
             if prog_counter == 1:
                 bar = ChargingBar(
                     max=1080, index=remain_time_rounded, suffix='%(percent)d%%')
-            else:
+            elif bar is not None:
                 bar.next()
 
         elif t2 < t1:


### PR DESCRIPTION
## Summary
- initialize `bar` before use in `terminal_clockv3`
- guard calling `bar.next()` until `bar` exists

## Testing
- `python3 -m py_compile terminal_clockv3.py`


------
https://chatgpt.com/codex/tasks/task_e_684058e691c8832593626dfa21eca7de