### PR TITLE
Refactor clock start time usage

### DIFF
--- a/terminal_clock.py
+++ b/terminal_clock.py
@@ -17,7 +17,7 @@ try:
     while True:
         os.system('cls')
         now = datetime.now()
-        start = datetime.now().time()
+        start = now.time()
 
         # Format current time
         t1 = timedelta(hours=start.hour, minutes=start.minute,

--- a/terminal_clockv3.py
+++ b/terminal_clockv3.py
@@ -15,7 +15,7 @@ try:
     while True:
         os.system('cls')
         now = datetime.now()
-        start = datetime.now().time()
+        start = now.time()
 
         # Format current time
         t1 = timedelta(hours=start.hour, minutes=start.minute,


### PR DESCRIPTION
## Summary
- reuse retrieved timestamp when reading time

## Testing
- `python3 -m py_compile terminal_clock.py terminal_clockv3.py`

------
https://chatgpt.com/codex/tasks/task_e_684058d716748325ab94b123e32ea3ab