### PR TITLE
Use cross-platform clear command

### DIFF
--- a/terminal_clock.py
+++ b/terminal_clock.py
@@ -15,7 +15,7 @@ prog_counter = 0
 
 try:
     while True:
-        os.system('cls')
+        os.system('cls' if os.name == 'nt' else 'clear')
         now = datetime.now()
         start = datetime.now().time()
 

--- a/terminal_clockv3.py
+++ b/terminal_clockv3.py
@@ -13,7 +13,7 @@ prog_counter = 0
 
 try:
     while True:
-        os.system('cls')
+        os.system('cls' if os.name == 'nt' else 'clear')
         now = datetime.now()
         start = datetime.now().time()
 


### PR DESCRIPTION
## Summary
- update `os.system('cls')` calls so `clear` is used on non-Windows systems

## Testing
- `python3 -m py_compile terminal_clock.py terminal_clockv3.py`


------
https://chatgpt.com/codex/tasks/task_e_684058ce517c8325861b33cfdd33b064