### PR TITLE
Fix progress bar description and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Terminal Time Tracking
+
+This repository provides simple scripts to display a clock and progress bar in the terminal.

--- a/terminal_clock.py
+++ b/terminal_clock.py
@@ -54,7 +54,7 @@ try:
             print("========================")
 
             # setup the progress bar
-            prog_bar.set_description("Progress:".format(remain_time_rounded))
+            prog_bar.set_description(f"Progress: {remain_time_rounded}")
 
             # check to see if it is the first run
             if prog_counter == 1:


### PR DESCRIPTION
## Summary
- add a simple README with basic description
- use an f-string when setting the progress bar description

## Testing
- `python -m py_compile terminal_clock.py terminal_clockv3.py`

------
https://chatgpt.com/codex/tasks/task_e_684058c94d748325853a55d105482bea